### PR TITLE
docs: add JSDoc comments to crypto utility functions

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -10,6 +10,10 @@ function deriveKey(passphrase) {
 /**
  * Encrypt a string using AES-256-GCM.
  * Returns base64(iv + authTag + ciphertext).
+ *
+ * @param {string} plaintext - The plaintext string to encrypt.
+ * @param {string} key - The passphrase used to derive the encryption key.
+ * @returns {string} Base64-encoded string containing the IV, auth tag, and ciphertext.
  */
 export function encryptValue(plaintext, key) {
   const keyHash = deriveKey(key)
@@ -28,6 +32,11 @@ export function encryptValue(plaintext, key) {
 /**
  * Decrypt an AES-256-GCM ciphertext.
  * Expects base64(iv + authTag + ciphertext).
+ *
+ * @param {string} ciphertext - Base64-encoded string containing the IV, auth tag, and ciphertext.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string} The decrypted plaintext string.
+ * @throws {Error} Throws if decryption fails (e.g., wrong key or corrupted data).
  */
 export function decryptValue(ciphertext, key) {
   const keyHash = deriveKey(key)
@@ -61,6 +70,10 @@ export function createEncryptedOutput(core, encryptionKey) {
 
 /**
  * Try to decrypt a value. Returns decrypted string on success, null on failure.
+ *
+ * @param {string} value - Base64-encoded encrypted string to attempt decryption on.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string|null} The decrypted plaintext string, or null if decryption fails.
  */
 export function tryDecrypt(value, key) {
   try {


### PR DESCRIPTION
Add @param, @returns, and @throws JSDoc tags to encryptValue, decryptValue, and tryDecrypt in src/crypto.js for contributor clarity.

Closes #11

Generated with [Claude Code](https://claude.ai/code)