### PR TITLE
docs: add JSDoc comments to crypto utility functions

### DIFF
--- a/base64-decode/dist/index.js
+++ b/base64-decode/dist/index.js
@@ -27527,6 +27527,10 @@ function deriveKey(passphrase) {
 /**
  * Encrypt a string using AES-256-GCM.
  * Returns base64(iv + authTag + ciphertext).
+ *
+ * @param {string} plaintext - The plaintext string to encrypt.
+ * @param {string} key - The passphrase used to derive the encryption key.
+ * @returns {string} Base64-encoded string containing the IV, auth tag, and ciphertext.
  */
 function encryptValue(plaintext, key) {
   const keyHash = deriveKey(key);

--- a/http/dist/index.js
+++ b/http/dist/index.js
@@ -27502,6 +27502,10 @@ function deriveKey(passphrase) {
 /**
  * Encrypt a string using AES-256-GCM.
  * Returns base64(iv + authTag + ciphertext).
+ *
+ * @param {string} plaintext - The plaintext string to encrypt.
+ * @param {string} key - The passphrase used to derive the encryption key.
+ * @returns {string} Base64-encoded string containing the IV, auth tag, and ciphertext.
  */
 function encryptValue(plaintext, key) {
   const keyHash = deriveKey(key);
@@ -27520,6 +27524,11 @@ function encryptValue(plaintext, key) {
 /**
  * Decrypt an AES-256-GCM ciphertext.
  * Expects base64(iv + authTag + ciphertext).
+ *
+ * @param {string} ciphertext - Base64-encoded string containing the IV, auth tag, and ciphertext.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string} The decrypted plaintext string.
+ * @throws {Error} Throws if decryption fails (e.g. wrong key or corrupted data).
  */
 function decryptValue(ciphertext, key) {
   const keyHash = deriveKey(key);
@@ -27539,6 +27548,10 @@ function decryptValue(ciphertext, key) {
 
 /**
  * Try to decrypt a value. Returns decrypted string on success, null on failure.
+ *
+ * @param {string} value - Base64-encoded encrypted string to attempt decryption on.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string|null} The decrypted plaintext string, or null if decryption fails.
  */
 function tryDecrypt(value, key) {
   try {
@@ -27717,7 +27730,8 @@ async function run() {
         const value = getNestedValue(parsed, fieldPath);
         if (value !== undefined) {
           const leafName = fieldPath.split('.').pop();
-          const strValue = typeof value === 'string' ? value : JSON.stringify(value);
+          const strValue =
+            typeof value === 'string' ? value : JSON.stringify(value);
           setOutput(leafName, strValue);
         }
       }

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -10,6 +10,10 @@ function deriveKey(passphrase) {
 /**
  * Encrypt a string using AES-256-GCM.
  * Returns base64(iv + authTag + ciphertext).
+ *
+ * @param {string} value - The plaintext string to encrypt.
+ * @param {string} key - The passphrase used to derive the encryption key.
+ * @returns {string} Base64-encoded string containing the IV, auth tag, and ciphertext.
  */
 export function encryptValue(plaintext, key) {
   const keyHash = deriveKey(key)
@@ -28,6 +32,11 @@ export function encryptValue(plaintext, key) {
 /**
  * Decrypt an AES-256-GCM ciphertext.
  * Expects base64(iv + authTag + ciphertext).
+ *
+ * @param {string} encrypted - Base64-encoded string containing the IV, auth tag, and ciphertext.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string} The decrypted plaintext string.
+ * @throws {Error} Throws if decryption fails (e.g. wrong key or corrupted data).
  */
 export function decryptValue(ciphertext, key) {
   const keyHash = deriveKey(key)
@@ -61,6 +70,10 @@ export function createEncryptedOutput(core, encryptionKey) {
 
 /**
  * Try to decrypt a value. Returns decrypted string on success, null on failure.
+ *
+ * @param {string} value - Base64-encoded encrypted string to attempt decryption on.
+ * @param {string} key - The passphrase used to derive the decryption key.
+ * @returns {string|null} The decrypted plaintext string, or null if decryption fails.
  */
 export function tryDecrypt(value, key) {
   try {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -11,7 +11,7 @@ function deriveKey(passphrase) {
  * Encrypt a string using AES-256-GCM.
  * Returns base64(iv + authTag + ciphertext).
  *
- * @param {string} value - The plaintext string to encrypt.
+ * @param {string} plaintext - The plaintext string to encrypt.
  * @param {string} key - The passphrase used to derive the encryption key.
  * @returns {string} Base64-encoded string containing the IV, auth tag, and ciphertext.
  */
@@ -33,7 +33,7 @@ export function encryptValue(plaintext, key) {
  * Decrypt an AES-256-GCM ciphertext.
  * Expects base64(iv + authTag + ciphertext).
  *
- * @param {string} encrypted - Base64-encoded string containing the IV, auth tag, and ciphertext.
+ * @param {string} ciphertext - Base64-encoded string containing the IV, auth tag, and ciphertext.
  * @param {string} key - The passphrase used to derive the decryption key.
  * @returns {string} The decrypted plaintext string.
  * @throws {Error} Throws if decryption fails (e.g. wrong key or corrupted data).

--- a/src/http/main.js
+++ b/src/http/main.js
@@ -137,7 +137,8 @@ export async function run() {
         const value = getNestedValue(parsed, fieldPath)
         if (value !== undefined) {
           const leafName = fieldPath.split('.').pop()
-          const strValue = typeof value === 'string' ? value : JSON.stringify(value)
+          const strValue =
+            typeof value === 'string' ? value : JSON.stringify(value)
           setOutput(leafName, strValue)
         }
       }


### PR DESCRIPTION
Add detailed JSDoc @param, @returns, and @throws annotations to `encryptValue`, `decryptValue`, and `tryDecrypt` in `src/crypto.js`.

Closes #13

Generated with [Claude Code](https://claude.ai/code)